### PR TITLE
Don't use forked version of cfn

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sinon": "4.0.1"
   },
   "dependencies": {
-    "cfn": "github:svozza/cfn#4ca3ceb446fcff944a52cd0811476f7e6e126650",
+    "cfn": "1.8.1",
     "highland": "2.11.1",
     "ramda": "0.25.0"
   }


### PR DESCRIPTION
Since my changes were merged on `cfn` we should use the official latest release.